### PR TITLE
Convert REAL to int for getLong in QueryCursor

### DIFF
--- a/src/main/java/com/facebook/presto/plugin/tiledb/TileDBRecordCursor.java
+++ b/src/main/java/com/facebook/presto/plugin/tiledb/TileDBRecordCursor.java
@@ -60,6 +60,7 @@ import static io.tiledb.java.api.QueryStatus.TILEDB_COMPLETED;
 import static io.tiledb.java.api.QueryStatus.TILEDB_INCOMPLETE;
 import static io.tiledb.java.api.QueryStatus.TILEDB_UNINITIALIZED;
 import static io.tiledb.java.api.Types.getJavaType;
+import static java.lang.Float.floatToRawIntBits;
 import static java.lang.String.format;
 import static java.util.Objects.requireNonNull;
 
@@ -957,6 +958,11 @@ public class TileDBRecordCursor
             case TILEDB_UINT64:
             case TILEDB_INT64: {
                 value = ((long[]) fieldArray)[index];
+                break;
+            }
+            // Presto converts 32bit floats to long types
+            case TILEDB_FLOAT32: {
+                value = ((Integer) floatToRawIntBits(((float[]) fieldArray)[index])).longValue();
                 break;
             }
         }

--- a/src/main/java/com/facebook/presto/plugin/tiledb/TileDBSplitManager.java
+++ b/src/main/java/com/facebook/presto/plugin/tiledb/TileDBSplitManager.java
@@ -44,6 +44,7 @@ import java.util.stream.Collectors;
 
 import static com.facebook.presto.plugin.tiledb.TileDBErrorCode.TILEDB_SPLIT_MANAGER_ERROR;
 import static com.facebook.presto.spi.predicate.Utils.nativeValueToBlock;
+import static com.facebook.presto.spi.type.RealType.REAL;
 import static java.util.Objects.requireNonNull;
 
 /**
@@ -208,7 +209,7 @@ public class TileDBSplitManager
         boolean maxFromNonEmptyDomain = true;
         // Number of buckets is 1 more thank number of splits (i.e. split 1 time into two buckets)
         // Only long dimensions can be split with naive algorithm
-        if (range.getType().getJavaType() == long.class) {
+        if (!REAL.equals(range.getType()) && range.getType().getJavaType() == long.class) {
             long min = (Long) ConvertUtils.convert(nonEmptyDomain.getFirst(), Long.class);
             if (range.getLow().getValueBlock().isPresent()) {
                 min = (Long) range.getLow().getValue();
@@ -257,6 +258,9 @@ public class TileDBSplitManager
                 // Set the low value to the high+1 for the next range split
                 low = high + 1;
             }
+        }
+        else {
+            ranges.add(range);
         }
         return ranges;
     }

--- a/src/test/java/com/facebook/presto/plugin/tiledb/TestTileDBQueries.java
+++ b/src/test/java/com/facebook/presto/plugin/tiledb/TestTileDBQueries.java
@@ -28,7 +28,11 @@ import org.testng.annotations.Test;
 import static com.facebook.presto.plugin.tiledb.TileDBErrorCode.TILEDB_UNEXPECTED_ERROR;
 import static com.facebook.presto.plugin.tiledb.TileDBQueryRunner.createTileDBQueryRunner;
 import static com.facebook.presto.spi.type.BigintType.BIGINT;
+import static com.facebook.presto.spi.type.DoubleType.DOUBLE;
 import static com.facebook.presto.spi.type.IntegerType.INTEGER;
+import static com.facebook.presto.spi.type.RealType.REAL;
+import static com.facebook.presto.spi.type.SmallintType.SMALLINT;
+import static com.facebook.presto.spi.type.TinyintType.TINYINT;
 import static com.facebook.presto.spi.type.VarcharType.VARCHAR;
 import static com.facebook.presto.testing.assertions.Assert.assertEquals;
 import static java.lang.String.format;
@@ -100,7 +104,7 @@ public class TestTileDBQueries
     }
 
     @Test
-    public void testCreate1DVectorAllDimensions()
+    public void testCreate1DVectorTinyInt()
     {
         String arrayName = "test_create_tinyint";
         // Tinyint
@@ -114,75 +118,167 @@ public class TestTileDBQueries
                         .row("a1", "integer", "", "Attribute")
                         .build());
 
-        dropArray(arrayName);
+        String insertSql = format("INSERT INTO %s (x, a1) VALUES " +
+                "(cast(0 as tinyint), 10), (cast(3 as tinyint), 13), (cast(5 as tinyint), 15)", arrayName);
+        getQueryRunner().execute(insertSql);
 
+        String selectSql = format("SELECT * FROM %s ORDER BY x ASC", arrayName);
+        MaterializedResult selectResult = computeActual(selectSql);
+        assertEquals(selectResult, MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), TINYINT, INTEGER)
+                .row((byte) 0, 10)
+                .row((byte) 3, 13)
+                .row((byte) 5, 15)
+                .build());
+
+        dropArray(arrayName);
+    }
+
+    @Test
+    public void testCreate1DVectorSmallInt()
+    {
         // Smallint
-        arrayName = "test_create_smallint";
+        String arrayName = "test_create_smallint";
         dropArray(arrayName);
         create1DVectorSmallIntDimension(arrayName);
 
-        desc = computeActual(format("DESC %s", arrayName)).toTestTypes();
+        MaterializedResult desc = computeActual(format("DESC %s", arrayName)).toTestTypes();
         assertEquals(desc,
                 MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
                         .row("x", "smallint", "", "Dimension")
                         .row("a1", "integer", "", "Attribute")
                         .build());
 
-        dropArray(arrayName);
+        String insertSql = format("INSERT INTO %s (x, a1) VALUES " +
+                "(cast(0 as smallint), 10), (cast(3 as smallint), 13), (cast(5 as smallint), 15)", arrayName);
+        getQueryRunner().execute(insertSql);
 
+        String selectSql = format("SELECT * FROM %s ORDER BY x ASC", arrayName);
+        MaterializedResult selectResult = computeActual(selectSql);
+        assertEquals(selectResult, MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), SMALLINT, INTEGER)
+                .row((short) 0, 10)
+                .row((short) 3, 13)
+                .row((short) 5, 15)
+                .build());
+
+        dropArray(arrayName);
+    }
+
+    @Test
+    public void testCreate1DVectorInteger()
+    {
         // Integer
-        arrayName = "test_create_integer";
+        String arrayName = "test_create_integer";
         dropArray(arrayName);
         create1DVectorIntegerDimension(arrayName);
 
-        desc = computeActual(format("DESC %s", arrayName)).toTestTypes();
+        MaterializedResult desc = computeActual(format("DESC %s", arrayName)).toTestTypes();
         assertEquals(desc,
                 MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
                         .row("x", "integer", "", "Dimension")
                         .row("a1", "integer", "", "Attribute")
                         .build());
 
-        dropArray(arrayName);
+        String insertSql = format("INSERT INTO %s (x, a1) VALUES " +
+                "(0, 10), (3, 13), (5, 15)", arrayName);
+        getQueryRunner().execute(insertSql);
 
+        String selectSql = format("SELECT * FROM %s ORDER BY x ASC", arrayName);
+        MaterializedResult selectResult = computeActual(selectSql);
+        assertEquals(selectResult, MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), INTEGER, INTEGER)
+                .row((int) 0, 10)
+                .row((int) 3, 13)
+                .row((int) 5, 15)
+                .build());
+
+        dropArray(arrayName);
+    }
+
+    @Test
+    public void testCreate1DVectorBigInt()
+    {
         // BigInt
-        arrayName = "test_create_bigint";
+        String arrayName = "test_create_bigint";
         dropArray(arrayName);
         create1DVector(arrayName);
 
-        desc = computeActual(format("DESC %s", arrayName)).toTestTypes();
+        MaterializedResult desc = computeActual(format("DESC %s", arrayName)).toTestTypes();
         assertEquals(desc,
                 MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
                         .row("x", "bigint", "", "Dimension")
                         .row("a1", "integer", "", "Attribute")
                         .build());
 
-        dropArray(arrayName);
+        String insertSql = format("INSERT INTO %s (x, a1) VALUES " +
+                "(0, 10), (3, 13), (5, 15)", arrayName);
+        getQueryRunner().execute(insertSql);
 
+        String selectSql = format("SELECT * FROM %s ORDER BY x ASC", arrayName);
+        MaterializedResult selectResult = computeActual(selectSql);
+        assertEquals(selectResult, MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), BIGINT, INTEGER)
+                .row((long) 0, 10)
+                .row((long) 3, 13)
+                .row((long) 5, 15)
+                .build());
+
+        dropArray(arrayName);
+    }
+
+    @Test
+    public void testCreate1DVectorReal()
+    {
         // Real
-        arrayName = "test_create_real";
+        String arrayName = "test_create_real";
         dropArray(arrayName);
         create1DVectorRealDimension(arrayName);
 
-        desc = computeActual(format("DESC %s", arrayName)).toTestTypes();
+        MaterializedResult desc = computeActual(format("DESC %s", arrayName)).toTestTypes();
         assertEquals(desc,
                 MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
                         .row("x", "real", "", "Dimension")
                         .row("a1", "integer", "", "Attribute")
                         .build());
 
-        dropArray(arrayName);
+        String insertSql = format("INSERT INTO %s (x, a1) VALUES " +
+                "(0.0, 10), (3.0, 13), (5.0, 15)", arrayName);
+        getQueryRunner().execute(insertSql);
 
+        String selectSql = format("SELECT * FROM %s ORDER BY x ASC", arrayName);
+        MaterializedResult selectResult = computeActual(selectSql);
+        assertEquals(selectResult, MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), REAL, INTEGER)
+                .row((float) 0.0, 10)
+                .row((float) 3.0, 13)
+                .row((float) 5.0, 15)
+                .build());
+
+        dropArray(arrayName);
+    }
+
+    @Test
+    public void testCreate1DVectorDouble()
+    {
         // Double
-        arrayName = "test_create_double";
+        String arrayName = "test_create_double";
         dropArray(arrayName);
         create1DVectorDoubleDimension(arrayName);
 
-        desc = computeActual(format("DESC %s", arrayName)).toTestTypes();
+        MaterializedResult desc = computeActual(format("DESC %s", arrayName)).toTestTypes();
         assertEquals(desc,
                 MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), VARCHAR, VARCHAR, VARCHAR, VARCHAR)
                         .row("x", "double", "", "Dimension")
                         .row("a1", "integer", "", "Attribute")
                         .build());
+
+        String insertSql = format("INSERT INTO %s (x, a1) VALUES " +
+                "(0.0, 10), (3.0, 13), (5.0, 15)", arrayName);
+        getQueryRunner().execute(insertSql);
+
+        String selectSql = format("SELECT * FROM %s ORDER BY x ASC", arrayName);
+        MaterializedResult selectResult = computeActual(selectSql);
+        assertEquals(selectResult, MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), DOUBLE, INTEGER)
+                .row((double) 0, 10)
+                .row((double) 3, 13)
+                .row((double) 5, 15)
+                .build());
 
         dropArray(arrayName);
     }


### PR DESCRIPTION
Also make sure REALs are excluded from integer splitting. Added additional unit tests to cover selecting all data types.

Closes #9