### PR TITLE
Convert created ranges to proper datatypes

### DIFF
--- a/src/main/java/com/facebook/presto/plugin/tiledb/TileDBSplitManager.java
+++ b/src/main/java/com/facebook/presto/plugin/tiledb/TileDBSplitManager.java
@@ -252,9 +252,14 @@ public class TileDBSplitManager
                     high += 1;
                     leftOvers--;
                 }
-                ranges.add(new Range(
-                        new Marker(range.getType(), Optional.of(nativeValueToBlock(range.getType(), low)), lowBound),
-                        new Marker(range.getType(), Optional.of(nativeValueToBlock(range.getType(), high)), upperBound)));
+
+                // Only set the range if the values are not equal or if the low
+                // and high are the bounds must also be the same
+                if (low != high || lowBound == upperBound) {
+                    ranges.add(new Range(
+                            new Marker(range.getType(), Optional.of(nativeValueToBlock(range.getType(), low)), lowBound),
+                            new Marker(range.getType(), Optional.of(nativeValueToBlock(range.getType(), high)), upperBound)));
+                }
                 // Set the low value to the high+1 for the next range split
                 low = high + 1;
             }

--- a/src/test/java/com/facebook/presto/plugin/tiledb/TestTileDBQueries.java
+++ b/src/test/java/com/facebook/presto/plugin/tiledb/TestTileDBQueries.java
@@ -130,6 +130,13 @@ public class TestTileDBQueries
                 .row((byte) 5, 15)
                 .build());
 
+        selectSql = format("SELECT * FROM %s WHERE x > 2 ORDER BY x ASC", arrayName);
+        selectResult = computeActual(selectSql);
+        assertEquals(selectResult, MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), TINYINT, INTEGER)
+                .row((byte) 3, 13)
+                .row((byte) 5, 15)
+                .build());
+
         dropArray(arrayName);
     }
 
@@ -156,6 +163,13 @@ public class TestTileDBQueries
         MaterializedResult selectResult = computeActual(selectSql);
         assertEquals(selectResult, MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), SMALLINT, INTEGER)
                 .row((short) 0, 10)
+                .row((short) 3, 13)
+                .row((short) 5, 15)
+                .build());
+
+        selectSql = format("SELECT * FROM %s WHERE x > 2 ORDER BY x ASC", arrayName);
+        selectResult = computeActual(selectSql);
+        assertEquals(selectResult, MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), SMALLINT, INTEGER)
                 .row((short) 3, 13)
                 .row((short) 5, 15)
                 .build());
@@ -190,6 +204,13 @@ public class TestTileDBQueries
                 .row((int) 5, 15)
                 .build());
 
+        selectSql = format("SELECT * FROM %s WHERE x > 2 ORDER BY x ASC", arrayName);
+        selectResult = computeActual(selectSql);
+        assertEquals(selectResult, MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), INTEGER, INTEGER)
+                .row((int) 3, 13)
+                .row((int) 5, 15)
+                .build());
+
         dropArray(arrayName);
     }
 
@@ -216,6 +237,13 @@ public class TestTileDBQueries
         MaterializedResult selectResult = computeActual(selectSql);
         assertEquals(selectResult, MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), BIGINT, INTEGER)
                 .row((long) 0, 10)
+                .row((long) 3, 13)
+                .row((long) 5, 15)
+                .build());
+
+        selectSql = format("SELECT * FROM %s WHERE x > 2 ORDER BY x ASC", arrayName);
+        selectResult = computeActual(selectSql);
+        assertEquals(selectResult, MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), BIGINT, INTEGER)
                 .row((long) 3, 13)
                 .row((long) 5, 15)
                 .build());
@@ -250,6 +278,13 @@ public class TestTileDBQueries
                 .row((float) 5.0, 15)
                 .build());
 
+        selectSql = format("SELECT * FROM %s WHERE x > 2 ORDER BY x ASC", arrayName);
+        selectResult = computeActual(selectSql);
+        assertEquals(selectResult, MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), REAL, INTEGER)
+                .row((float) 3.0, 13)
+                .row((float) 5.0, 15)
+                .build());
+
         dropArray(arrayName);
     }
 
@@ -278,6 +313,13 @@ public class TestTileDBQueries
                 .row((double) 0, 10)
                 .row((double) 3, 13)
                 .row((double) 5, 15)
+                .build());
+
+        selectSql = format("SELECT * FROM %s WHERE x > 2 ORDER BY x ASC", arrayName);
+        selectResult = computeActual(selectSql);
+        assertEquals(selectResult, MaterializedResult.resultBuilder(getQueryRunner().getDefaultSession(), DOUBLE, INTEGER)
+                .row((double) 3.0, 13)
+                .row((double) 5.0, 15)
                 .build());
 
         dropArray(arrayName);


### PR DESCRIPTION
Convert created ranges to proper datatypes. This effects when we add missing dimension ranges for splits

Closes #14