### PR TITLE
Build TileDB context from session for all Array Accesses

### DIFF
--- a/src/main/java/com/facebook/presto/plugin/tiledb/TileDBMetadata.java
+++ b/src/main/java/com/facebook/presto/plugin/tiledb/TileDBMetadata.java
@@ -146,7 +146,7 @@ public class TileDBMetadata
         Map<ColumnHandle, Domain> enforceableDimensionDomains = new HashMap<>(Maps.filterKeys(effectivePredicate.getDomains().get(), Predicates.in(dimensionHandles)));
 
         if (!getSplitOnlyPredicates(session)) {
-            try (Array array = new Array(tileDBClient.getCtx(), tableHandle.getURI().toString(), TILEDB_READ)) {
+            try (Array array = new Array(tileDBClient.buildContext(session), tableHandle.getURI().toString(), TILEDB_READ)) {
                 HashMap<String, Pair> nonEmptyDomain = array.nonEmptyDomain();
                 // Find any dimension which do not have predicates and add one for the entire domain.
                 // This is required so we can later split on the predicates

--- a/src/main/java/com/facebook/presto/plugin/tiledb/TileDBPageSink.java
+++ b/src/main/java/com/facebook/presto/plugin/tiledb/TileDBPageSink.java
@@ -99,11 +99,12 @@ public class TileDBPageSink
     public TileDBPageSink(TileDBOutputTableHandle handle, TileDBClient tileDBClient, ConnectorSession session)
     {
         try {
+            ctx = tileDBClient.buildContext(session);
             // Set max write buffer size from session configuration parameter
             this.maxBufferSize = getWriteBufferSize(session);
 
             // Open the array in write mode
-            array = new Array(tileDBClient.getCtx(), handle.getURI(), QueryType.TILEDB_WRITE);
+            array = new Array(ctx, handle.getURI(), QueryType.TILEDB_WRITE);
             // Create query object
             query = new Query(array, QueryType.TILEDB_WRITE);
             // All writes are unordered
@@ -131,7 +132,6 @@ public class TileDBPageSink
         for (int i = 0; i < columnNames.size(); i++) {
             columnOrder.put(columnNames.get(i), i);
         }
-        ctx = tileDBClient.getCtx();
     }
 
     /**

--- a/src/main/java/com/facebook/presto/plugin/tiledb/TileDBRecordSet.java
+++ b/src/main/java/com/facebook/presto/plugin/tiledb/TileDBRecordSet.java
@@ -60,7 +60,7 @@ public class TileDBRecordSet
         TileDBTable table = tileDBClient.getTable(session, split.getSchemaName(), split.getTableName());
         requireNonNull(table, "Unable to fetch table " + split.getSchemaName() + "." + split.getTableName() + " for record set");
         try {
-            array = new Array(tileDBClient.getCtx(), table.getURI().toString(), TILEDB_READ);
+            array = new Array(tileDBClient.buildContext(session), table.getURI().toString(), TILEDB_READ);
             query = new Query(array, TILEDB_READ);
             query.setLayout(Layout.TILEDB_GLOBAL_ORDER);
         }


### PR DESCRIPTION
Build TileDB context from session for all Array Accesses. Fixes #20

Note: This has the downside of invalidating caches. To keep tiledb caching in effect we need to support changing configuration parameters of an existing tiledb context.