### PR TITLE
Fix column case sensitivity for inserts

### DIFF
--- a/src/main/java/com/facebook/presto/plugin/tiledb/TileDBColumn.java
+++ b/src/main/java/com/facebook/presto/plugin/tiledb/TileDBColumn.java
@@ -16,6 +16,7 @@ package com.facebook.presto.plugin.tiledb;
 import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.tiledb.java.api.Datatype;
 
 import java.util.Objects;
 
@@ -35,17 +36,23 @@ public final class TileDBColumn
 {
     private final String name;
     private final Type type;
+    private final Datatype tileDBType;
+    private final Boolean isVariableLength;
     private final Boolean isDimension;
 
     @JsonCreator
     public TileDBColumn(
             @JsonProperty("name") String name,
             @JsonProperty("type") Type type,
+            @JsonProperty("TileDBType") Datatype tileDBType,
+            @JsonProperty("isVariableLength") Boolean isVariableLength,
             @JsonProperty("isDimension") Boolean isDimension)
     {
         checkArgument(!isNullOrEmpty(name), "name is null or is empty");
         this.name = name;
         this.type = requireNonNull(type, "type is null");
+        this.tileDBType = requireNonNull(tileDBType, "TileDBType is null");
+        this.isVariableLength = requireNonNull(isVariableLength, "isVariableLength is null");
         this.isDimension = requireNonNull(isDimension, "isDimension is null");
     }
 
@@ -53,6 +60,18 @@ public final class TileDBColumn
     public String getName()
     {
         return name;
+    }
+
+    @JsonProperty
+    public Datatype getTileDBType()
+    {
+        return tileDBType;
+    }
+
+    @JsonProperty
+    public Boolean getIsVariableLength()
+    {
+        return isVariableLength;
     }
 
     @JsonProperty

--- a/src/main/java/com/facebook/presto/plugin/tiledb/TileDBColumnHandle.java
+++ b/src/main/java/com/facebook/presto/plugin/tiledb/TileDBColumnHandle.java
@@ -18,6 +18,7 @@ import com.facebook.presto.spi.ColumnMetadata;
 import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
+import io.tiledb.java.api.Datatype;
 
 import java.util.Objects;
 
@@ -36,6 +37,8 @@ public final class TileDBColumnHandle
     private final String connectorId;
     private final String columnName;
     private final Type columnType;
+    private final Datatype columnTileDBType;
+    private final boolean isVariableLength;
     private final boolean isDimension;
 
     @JsonCreator
@@ -43,11 +46,15 @@ public final class TileDBColumnHandle
             @JsonProperty("connectorId") String connectorId,
             @JsonProperty("columnName") String columnName,
             @JsonProperty("columnType") Type columnType,
+            @JsonProperty("columnTileDBType") Datatype columnTileDBType,
+            @JsonProperty("isVariableLength") Boolean isVariableLength,
             @JsonProperty("isDimension") Boolean isDimension)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
         this.columnName = requireNonNull(columnName, "columnName is null");
         this.columnType = requireNonNull(columnType, "columnType is null");
+        this.columnTileDBType = requireNonNull(columnTileDBType, "columnTileDBType is null");
+        this.isVariableLength = requireNonNull(isVariableLength, "isVariableLength is null");
         this.isDimension = requireNonNull(isDimension, "isDimension is null");
     }
 
@@ -67,6 +74,18 @@ public final class TileDBColumnHandle
     public Type getColumnType()
     {
         return columnType;
+    }
+
+    @JsonProperty
+    public Datatype getColumnTileDBType()
+    {
+        return columnTileDBType;
+    }
+
+    @JsonProperty
+    public Boolean getIsVariableLength()
+    {
+        return isVariableLength;
     }
 
     @JsonProperty
@@ -110,6 +129,8 @@ public final class TileDBColumnHandle
                 .add("connectorId", connectorId)
                 .add("columnName", columnName)
                 .add("columnType", columnType)
+                .add("columnTileDBType", columnTileDBType)
+                .add("isVariableLength", isVariableLength)
                 .add("isDimension", isDimension)
                 .toString();
     }

--- a/src/main/java/com/facebook/presto/plugin/tiledb/TileDBOutputTableHandle.java
+++ b/src/main/java/com/facebook/presto/plugin/tiledb/TileDBOutputTableHandle.java
@@ -15,17 +15,14 @@ package com.facebook.presto.plugin.tiledb;
 
 import com.facebook.presto.spi.ConnectorInsertTableHandle;
 import com.facebook.presto.spi.ConnectorOutputTableHandle;
-import com.facebook.presto.spi.type.Type;
 import com.fasterxml.jackson.annotation.JsonCreator;
 import com.fasterxml.jackson.annotation.JsonProperty;
-import com.google.common.collect.ImmutableList;
 
 import javax.annotation.Nullable;
 
 import java.util.List;
 import java.util.Objects;
 
-import static com.google.common.base.Preconditions.checkArgument;
 import static java.util.Objects.requireNonNull;
 
 public class TileDBOutputTableHandle
@@ -35,9 +32,8 @@ public class TileDBOutputTableHandle
     private final String catalogName;
     private final String schemaName;
     private final String tableName;
-    private final List<String> columnNames;
-    private final List<Type> columnTypes;
     private final String uri;
+    private final List<TileDBColumnHandle> columnHandles;
 
     @JsonCreator
     public TileDBOutputTableHandle(
@@ -45,8 +41,7 @@ public class TileDBOutputTableHandle
             @JsonProperty("catalogName") @Nullable String catalogName,
             @JsonProperty("schemaName") @Nullable String schemaName,
             @JsonProperty("tableName") String tableName,
-            @JsonProperty("columnNames") List<String> columnNames,
-            @JsonProperty("columnTypes") List<Type> columnTypes,
+            @JsonProperty("columnHandles") List<TileDBColumnHandle> columnHandles,
             @JsonProperty("uri") String uri)
     {
         this.connectorId = requireNonNull(connectorId, "connectorId is null");
@@ -54,11 +49,7 @@ public class TileDBOutputTableHandle
         this.schemaName = schemaName;
         this.tableName = requireNonNull(tableName, "tableName is null");
 
-        requireNonNull(columnNames, "columnNames is null");
-        requireNonNull(columnTypes, "columnTypes is null");
-        checkArgument(columnNames.size() == columnTypes.size(), "columnNames and columnTypes sizes don't match");
-        this.columnNames = ImmutableList.copyOf(columnNames);
-        this.columnTypes = ImmutableList.copyOf(columnTypes);
+        this.columnHandles = requireNonNull(columnHandles, "columnHandles is null");
         this.uri = requireNonNull(uri, "uri is null");
     }
 
@@ -89,15 +80,9 @@ public class TileDBOutputTableHandle
     }
 
     @JsonProperty
-    public List<String> getColumnNames()
+    public List<TileDBColumnHandle> getColumnHandles()
     {
-        return columnNames;
-    }
-
-    @JsonProperty
-    public List<Type> getColumnTypes()
-    {
-        return columnTypes;
+        return columnHandles;
     }
 
     @JsonProperty
@@ -120,8 +105,7 @@ public class TileDBOutputTableHandle
                 catalogName,
                 schemaName,
                 tableName,
-                columnNames,
-                columnTypes,
+                columnHandles,
                 uri);
     }
 

--- a/src/main/java/com/facebook/presto/plugin/tiledb/TileDBRecordSet.java
+++ b/src/main/java/com/facebook/presto/plugin/tiledb/TileDBRecordSet.java
@@ -69,22 +69,6 @@ public class TileDBRecordSet
         }
     }
 
-   /* private Query buildSubArray(Query query, List<TileDBColumnHandle> columnHandles, TupleDomain<ColumnHandle> tupleDomain) {
-        // Loop through columns to find attributes.
-        // We need find the dimension limitations so we can build the subarray
-        for (TileDBColumnHandle column : columnHandles) {
-            if(column.getIsDimension()) {
-                Domain domain = tupleDomain.getDomains().get().get(column);
-                if (domain != null) {
-                    for (Range range : domain.getValues().getRanges().getOrderedRanges()) {
-                        //range.getHigh()
-                    }
-                }
-            }
-        }
-        return query;
-    }*/
-
     @Override
     public List<Type> getColumnTypes()
     {

--- a/src/main/java/com/facebook/presto/plugin/tiledb/TileDBTable.java
+++ b/src/main/java/com/facebook/presto/plugin/tiledb/TileDBTable.java
@@ -65,7 +65,7 @@ public class TileDBTable
         for (Dimension dimension : domain.getDimensions()) {
             Type type = prestoTypeFromTileDBType(dimension.getType());
             columnsMetadata.add(new ColumnMetadata(dimension.getName(), type, "Dimension", null, false));
-            columns.add(new TileDBColumn(dimension.getName(), type, true));
+            columns.add(new TileDBColumn(dimension.getName(), type, dimension.getType(), false, true));
             dimension.close();
         }
         // Add attribute as a column
@@ -76,7 +76,7 @@ public class TileDBTable
                 type = VarcharType.createVarcharType(toIntExact(attribute.getCellValNum()));
             }
             columnsMetadata.add(new ColumnMetadata(attribute.getName(), type, "Attribute", null, false));
-            columns.add(new TileDBColumn(attribute.getName(), type, false));
+            columns.add(new TileDBColumn(attribute.getName(), type, attribute.getType(), attribute.isVar(), false));
             attribute.close();
         }
         domain.close();


### PR DESCRIPTION
This fixes cases where the tiledb columns are not lowercase but persto olumn metadata forces all columns lowercase. Now for inserts instead of using column metadata we extend and use only TileDBColumnHandle. This class contains the original column name used for inserts.

Closes #23