### PR TITLE
Update TileDB-Java to version 0.1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>io.tiledb</groupId>
             <artifactId>tiledb-java</artifactId>
-            <version>0.1.6</version>
+            <version>0.1.7</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
This update bundled tiledb to 1.6.2 and update the march used for the native tiledb to support core2 for improved performance via sse optimizations