### PR TITLE
Add support for arbitrary TileDB Config Parameters

### DIFF
--- a/docs/Configuration.md
+++ b/docs/Configuration.md
@@ -22,6 +22,7 @@ plugin-wide.
 | write-buffer-size | 10485760 | Integer | Set the max write buffer size per attribute |
 | aws-access-key-id | "" | String | AWS_ACCESS_KEY_ID for s3 access |
 | aws-secret-access-key | "" | String | AWS_SECRET_ACCESS_KEY for s3 access |
+| tiledb-config | "" | String | TileDB config parameters in key1=value1,key2=value2 form |
 
 
 ## Session Parameters
@@ -39,3 +40,4 @@ the plugin configuration default for the equivalent setting.
 | splits | -1 | Integer | Set the number of splits to use per query, -1 means splits will be equal to number of workers |
 | split_only_predicates | false | Boolean | Split only based on predicates pushed down from where clause. For sparse array splitting evening across all domains can create skewed splits |
 | enable_stats | false | Boolean | Enable collecting and dumping of connector stats to presto log |
+| tiledb_config | "" | String | TileDB config parameters in key1=value1,key2=value2 form |

--- a/src/main/java/io/prestosql/plugin/tiledb/TileDBConfig.java
+++ b/src/main/java/io/prestosql/plugin/tiledb/TileDBConfig.java
@@ -41,6 +41,8 @@ public class TileDBConfig
 
     private String awsSecretAccessKey;
 
+    private String tileDBConfig;
+
     public Set<URI> getArrayURIs()
     {
         return arrayURIs;
@@ -64,6 +66,11 @@ public class TileDBConfig
     public String getAwsSecretAccessKey()
     {
         return awsSecretAccessKey;
+    }
+
+    public String getTileDBConfig()
+    {
+        return tileDBConfig;
     }
 
     @ConfigDescription("A comma separated list of array uris")
@@ -117,6 +124,14 @@ public class TileDBConfig
     public TileDBConfig setAwsSecretAccessKey(String awsSecretAccessKey)
     {
         this.awsSecretAccessKey = awsSecretAccessKey;
+        return this;
+    }
+
+    @ConfigDescription("TileDB config parameters in key1=value1,key2=value2 form")
+    @Config("tiledb-config")
+    public TileDBConfig setTileDBConfig(String tileDBConfig)
+    {
+        this.tileDBConfig = tileDBConfig;
         return this;
     }
 }

--- a/src/main/java/io/prestosql/plugin/tiledb/TileDBSessionProperties.java
+++ b/src/main/java/io/prestosql/plugin/tiledb/TileDBSessionProperties.java
@@ -34,6 +34,7 @@ public final class TileDBSessionProperties
     private static final String SPLITS = "splits";
     private static final String SPLIT_ONLY_PREDICATES = "split_only_predicates";
     private static final String ENABLE_STATS = "enable_stats";
+    private static final String TILEDB_CONFIG = "tiledb_config";
 
     private final List<PropertyMetadata<?>> sessionProperties;
 
@@ -75,6 +76,11 @@ public final class TileDBSessionProperties
                         ENABLE_STATS,
                         "Enable tiledb and connector stats per query",
                         false,
+                        false),
+                stringProperty(
+                        TILEDB_CONFIG,
+                        "TileDB config parameters in key1=value1,key2=value2 form",
+                        tileDBConfig.getTileDBConfig(),
                         false));
     }
 
@@ -116,5 +122,10 @@ public final class TileDBSessionProperties
     public static boolean getEnableStats(ConnectorSession session)
     {
         return session.getProperty(ENABLE_STATS, Boolean.class);
+    }
+
+    public static String getTileDBConfig(ConnectorSession session)
+    {
+        return session.getProperty(TILEDB_CONFIG, String.class);
     }
 }

--- a/src/test/java/io/prestosql/plugin/tiledb/TestTileDBConfig.java
+++ b/src/test/java/io/prestosql/plugin/tiledb/TestTileDBConfig.java
@@ -32,7 +32,8 @@ public class TestTileDBConfig
                 .setReadBufferSize(10485760)
                 .setWriteBufferSize(10485760)
                 .setAwsAccessKeyId(null)
-                .setAwsSecretAccessKey(null));
+                .setAwsSecretAccessKey(null)
+                .setTileDBConfig(null));
     }
 
     @Test
@@ -43,7 +44,8 @@ public class TestTileDBConfig
                 .put("read-buffer-size", "10")
                 .put("write-buffer-size", "100")
                 .put("aws-access-key-id", "")
-                .put("aws-secret-access-key", "").build();
+                .put("aws-secret-access-key", "")
+                .put("tiledb-config", "").build();
 
         TileDBConfig expected = null;
         expected = new TileDBConfig()
@@ -51,7 +53,8 @@ public class TestTileDBConfig
                 .setReadBufferSize(10)
                 .setWriteBufferSize(100)
                 .setAwsAccessKeyId("")
-                .setAwsSecretAccessKey("");
+                .setAwsSecretAccessKey("")
+                .setTileDBConfig("");
         assertFullMapping(properties, expected);
     }
 
@@ -63,7 +66,8 @@ public class TestTileDBConfig
                 .put("read-buffer-size", "1048576")
                 .put("write-buffer-size", "1048576")
                 .put("aws-access-key-id", "123")
-                .put("aws-secret-access-key", "abc").build();
+                .put("aws-secret-access-key", "abc")
+                .put("tiledb-config", "key1=value1,key2=value2").build();
 
         TileDBConfig expected = null;
         expected = new TileDBConfig()
@@ -71,7 +75,8 @@ public class TestTileDBConfig
                 .setReadBufferSize(1048576)
                 .setWriteBufferSize(1048576)
                 .setAwsAccessKeyId("123")
-                .setAwsSecretAccessKey("abc");
+                .setAwsSecretAccessKey("abc")
+                .setTileDBConfig("key1=value1,key2=value2");
         assertFullMapping(properties, expected);
     }
 }


### PR DESCRIPTION
Add support for arbitrary TileDB Config Parameters. This will be rebased after #44  is merged.