### PR TITLE
Update to TileDB-Java 0.3.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -16,7 +16,7 @@
         <dependency>
             <groupId>io.tiledb</groupId>
             <artifactId>tiledb-java</artifactId>
-            <version>0.3.1</version>
+            <version>0.3.2</version>
         </dependency>
 
         <dependency>


### PR DESCRIPTION
The new 0.3.2 prebuilt jar has S3 and TileDB Cloud support enabled